### PR TITLE
The sign-in action appears to have changed from sign-me-in to sign-in

### DIFF
--- a/src/our-groceries-client.js
+++ b/src/our-groceries-client.js
@@ -26,7 +26,7 @@ OurGroceriesClient.prototype.authenticate = function(username, password, complet
     url:urls.signIn,
     form: {
       emailAddress:username,
-      action:"sign-me-in",
+      action:"sign-in",
       password:password,
       staySignedIn:"on"
     },


### PR DESCRIPTION
I have started getting authentication errors, and it appears like OurGroceries changed their sign-in action parameter from sign-me-in to just sign-in. This fixes the issue for me. 